### PR TITLE
license: moved  License information to LICENSE.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,10 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+=======================================================================
+
+The Apache APISIX project bundles the following dependencies under the MIT license. (https://opensource.org/licenses/MIT)
+See bundled license files for details.
+
+- vue-element-admin: https://github.com/PanJiaChen/vue-element-admin

--- a/NOTICE
+++ b/NOTICE
@@ -3,8 +3,3 @@ Copyright 2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
-This project bundles the following dependencies under the MIT license. (https://opensource.org/licenses/MIT)
-See bundled license files for details.
-
-- vue-element-admin: https://github.com/PanJiaChen/vue-element-admin


### PR DESCRIPTION
fixed https://github.com/apache/incubator-apisix-dashboard/issues/54