### PR TITLE
fix run "npm run serve" command, notice "Request failed with status c…

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -28,7 +28,7 @@ module.exports = {
   productionSourceMap: false,
   devServer: {
     // https://cli.vuejs.org/zh/config/#devserver-proxy
-    proxy: 'http://127.0.0.1/apisix/admin/'
+    proxy: 'http://127.0.0.1:9080/apisix/admin/'
   },
   pwa: {
     name: name,


### PR DESCRIPTION
fix run "npm run serve" command, notice "Request failed with status code 500"

because the apisix server default listen 9080 on develop environment.