### PR TITLE
Fix incorrect format of some go source files

### DIFF
--- a/api/conf/conf.go
+++ b/api/conf/conf.go
@@ -18,11 +18,12 @@ package conf
 
 import (
 	"fmt"
-	"github.com/tidwall/gjson"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
+
+	"github.com/tidwall/gjson"
 )
 
 const ServerPort = 8080

--- a/api/conf/mysql.go
+++ b/api/conf/mysql.go
@@ -18,9 +18,10 @@ package conf
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/mysql"
-	"time"
 )
 
 var db *gorm.DB

--- a/api/filter/logging.go
+++ b/api/filter/logging.go
@@ -18,10 +18,11 @@ package filter
 
 import (
 	"bytes"
+	"time"
+
 	"github.com/apisix/manager-api/errno"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
-	"time"
 )
 
 func RequestLogHandler() gin.HandlerFunc {

--- a/api/filter/recover.go
+++ b/api/filter/recover.go
@@ -19,13 +19,14 @@ package filter
 import (
 	"bytes"
 	"fmt"
-	"github.com/apisix/manager-api/log"
-	"github.com/gin-gonic/gin"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
 	"runtime"
 	"time"
+
+	"github.com/apisix/manager-api/log"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/api/filter/request_id.go
+++ b/api/filter/request_id.go
@@ -18,7 +18,6 @@ package filter
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/satori/go.uuid"
 )
 
 func RequestId() gin.HandlerFunc {

--- a/api/log/log.go
+++ b/api/log/log.go
@@ -19,11 +19,12 @@ package log
 import (
 	"bufio"
 	"fmt"
-	"github.com/apisix/manager-api/conf"
-	"github.com/sirupsen/logrus"
 	"os"
 	"runtime"
 	"strings"
+
+	"github.com/apisix/manager-api/conf"
+	"github.com/sirupsen/logrus"
 )
 
 var logEntry *logrus.Entry

--- a/api/main.go
+++ b/api/main.go
@@ -18,14 +18,15 @@ package main
 
 import (
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/apisix/manager-api/conf"
 	"github.com/apisix/manager-api/filter"
 	"github.com/apisix/manager-api/log"
 	"github.com/apisix/manager-api/route"
 	"github.com/gin-contrib/pprof"
 	"github.com/gin-gonic/gin"
-	"net/http"
-	"time"
 )
 
 var logger = log.GetLogger()

--- a/api/route/consumer.go
+++ b/api/route/consumer.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/satori/go.uuid"
 
 	"github.com/apisix/manager-api/conf"
 	"github.com/apisix/manager-api/errno"

--- a/api/route/healthz.go
+++ b/api/route/healthz.go
@@ -17,9 +17,10 @@
 package route
 
 import (
+	"net/http"
+
 	"github.com/apisix/manager-api/log"
 	"github.com/gin-gonic/gin"
-	"net/http"
 )
 
 var logger = log.GetLogger()

--- a/api/route/plugin.go
+++ b/api/route/plugin.go
@@ -18,10 +18,11 @@ package route
 
 import (
 	"encoding/json"
+	"net/http"
+
 	"github.com/apisix/manager-api/errno"
 	"github.com/apisix/manager-api/service"
 	"github.com/gin-gonic/gin"
-	"net/http"
 )
 
 func AppendPlugin(r *gin.Engine) *gin.Engine {

--- a/api/route/route.go
+++ b/api/route/route.go
@@ -18,13 +18,13 @@ package route
 
 import (
 	"encoding/json"
+	"net/http"
+	"strconv"
+
 	"github.com/apisix/manager-api/conf"
 	"github.com/apisix/manager-api/errno"
 	"github.com/apisix/manager-api/service"
 	"github.com/gin-gonic/gin"
-	"github.com/satori/go.uuid"
-	"net/http"
-	"strconv"
 )
 
 func AppendRoute(r *gin.Engine) *gin.Engine {

--- a/api/route/ssl.go
+++ b/api/route/ssl.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/satori/go.uuid"
 
 	"github.com/apisix/manager-api/conf"
 	"github.com/apisix/manager-api/errno"

--- a/api/route/upstream.go
+++ b/api/route/upstream.go
@@ -3,13 +3,13 @@ package route
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strconv"
+
 	"github.com/apisix/manager-api/conf"
 	"github.com/apisix/manager-api/errno"
 	"github.com/apisix/manager-api/service"
 	"github.com/gin-gonic/gin"
-	"github.com/satori/go.uuid"
-	"net/http"
-	"strconv"
 )
 
 func AppendUpstream(r *gin.Engine) *gin.Engine {
@@ -50,10 +50,10 @@ func createUpstream(c *gin.Context) {
 	} else {
 		// apisix
 		if resp, err := aur.Create(); err != nil {
-				e := errno.FromMessage(errno.ApisixUpstreamCreateError, err.Error())
-				logger.Error(e.Msg)
-				c.AbortWithStatusJSON(http.StatusInternalServerError, e.Response())
-				return
+			e := errno.FromMessage(errno.ApisixUpstreamCreateError, err.Error())
+			logger.Error(e.Msg)
+			c.AbortWithStatusJSON(http.StatusInternalServerError, e.Response())
+			return
 		} else {
 			// mysql
 			fmt.Println(resp.UNode.UValue.Id)
@@ -76,7 +76,7 @@ func createUpstream(c *gin.Context) {
 
 func findUpstream(c *gin.Context) {
 	uid := c.Param("uid")
-		// find from apisix
+	// find from apisix
 	aur := &service.ApisixUpstreamRequest{Id: uid}
 	if resp, err := aur.FindById(); err != nil {
 		e := errno.FromMessage(errno.UpstreamRequestError, err.Error()+" upstream ID: "+uid)

--- a/api/service/base.go
+++ b/api/service/base.go
@@ -17,9 +17,9 @@
 package service
 
 import (
-	"github.com/jinzhu/gorm"
-	"github.com/satori/go.uuid"
 	"time"
+
+	"github.com/jinzhu/gorm"
 )
 
 // Base contains common columns for all tables.

--- a/api/service/consumer.go
+++ b/api/service/consumer.go
@@ -20,8 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/satori/go.uuid"
-
 	"github.com/apisix/manager-api/conf"
 	"github.com/apisix/manager-api/errno"
 	"github.com/apisix/manager-api/utils"

--- a/api/service/consumer_test.go
+++ b/api/service/consumer_test.go
@@ -19,7 +19,6 @@ package service
 import (
 	"testing"
 
-	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/apisix/manager-api/errno"

--- a/api/service/plugin.go
+++ b/api/service/plugin.go
@@ -19,6 +19,7 @@ package service
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/apisix/manager-api/conf"
 	"github.com/apisix/manager-api/utils"
 )

--- a/api/service/route.go
+++ b/api/service/route.go
@@ -19,12 +19,12 @@ package service
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/apisix/manager-api/conf"
 	"github.com/apisix/manager-api/errno"
 	"github.com/apisix/manager-api/log"
 	"github.com/apisix/manager-api/utils"
-	"github.com/satori/go.uuid"
-	"time"
 )
 
 const (
@@ -101,7 +101,7 @@ func (arr *ApisixRouteRequest) Update(rid string) (*ApisixRouteResponse, error) 
 	if b, err := json.Marshal(arr); err != nil {
 		return nil, err
 	} else {
-    fmt.Println(string(b))
+		fmt.Println(string(b))
 		if resp, err := utils.Put(url, b); err != nil {
 			logger.Error(err.Error())
 			return nil, err
@@ -166,7 +166,7 @@ type RouteRequest struct {
 	Redirect         *Redirect              `json:"redirect,omitempty"`
 	Vars             [][]string             `json:"vars,omitempty"`
 	Upstream         *Upstream              `json:"upstream,omitempty"`
-	UpstreamId       string              `json:"upstream_id,omitempty"`
+	UpstreamId       string                 `json:"upstream_id,omitempty"`
 	UpstreamProtocol string                 `json:"upstream_protocol,omitempty"`
 	UpstreamPath     *UpstreamPath          `json:"upstream_path,omitempty"`
 	UpstreamHeader   map[string]string      `json:"upstream_header,omitempty"`
@@ -249,7 +249,7 @@ func (r *ApisixRouteResponse) Parse() (*RouteRequest, error) {
 		upstreamHeader = nil
 		upstreamPath = nil
 	}
-  if upstreamPath != nil && upstreamPath.UPathType == "" {
+	if upstreamPath != nil && upstreamPath.UPathType == "" {
 		upstreamPath = nil
 	}
 	result := &RouteRequest{
@@ -344,15 +344,15 @@ type UpstreamPath struct {
 }
 
 type ApisixRouteRequest struct {
-	Desc     string                 `json:"desc,omitempty"`
-	Priority int64                  `json:"priority"`
-	Methods  []string               `json:"methods,omitempty"`
-	Uris     []string               `json:"uris,omitempty"`
-	Hosts    []string               `json:"hosts,omitempty"`
-	Vars     [][]string             `json:"vars,omitempty"`
-	Upstream *Upstream              `json:"upstream,omitempty"`
+	Desc       string                 `json:"desc,omitempty"`
+	Priority   int64                  `json:"priority"`
+	Methods    []string               `json:"methods,omitempty"`
+	Uris       []string               `json:"uris,omitempty"`
+	Hosts      []string               `json:"hosts,omitempty"`
+	Vars       [][]string             `json:"vars,omitempty"`
+	Upstream   *Upstream              `json:"upstream,omitempty"`
 	UpstreamId string                 `json:"upstream_id,omitempty"`
-	Plugins  map[string]interface{} `json:"plugins,omitempty"`
+	Plugins    map[string]interface{} `json:"plugins,omitempty"`
 	//Name     string                 `json:"name"`
 }
 

--- a/api/service/route_test.go
+++ b/api/service/route_test.go
@@ -18,8 +18,9 @@ package service
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRedirectMarshal(t *testing.T) {

--- a/api/service/ssl.go
+++ b/api/service/ssl.go
@@ -24,8 +24,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/satori/go.uuid"
-
 	"github.com/apisix/manager-api/conf"
 	"github.com/apisix/manager-api/errno"
 	"github.com/apisix/manager-api/utils"

--- a/api/service/ssl_test.go
+++ b/api/service/ssl_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/apisix/manager-api/errno"

--- a/api/service/upstream.go
+++ b/api/service/upstream.go
@@ -3,10 +3,10 @@ package service
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/apisix/manager-api/conf"
 	"github.com/apisix/manager-api/errno"
 	"github.com/apisix/manager-api/utils"
-	"github.com/satori/go.uuid"
 )
 
 type UpstreamDao struct {

--- a/api/utils/http.go
+++ b/api/utils/http.go
@@ -18,11 +18,12 @@ package utils
 
 import (
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/apisix/manager-api/conf"
 	"github.com/apisix/manager-api/log"
 	"gopkg.in/resty.v1"
-	"net/http"
-	"time"
 )
 
 const timeout = 3000


### PR DESCRIPTION
Use `gofmt` command to format codes, as well as re-organize the imports in a conventional way via `goimports` command. 

> BTW: I guess that would be great if we add these two command to make static check for go codes. Maybe that could be done in another PR.

Signed-off-by: imjoey <majunjiev@gmail.com>