### PR TITLE
fix a  plugin dialog can't reopen bug

### DIFF
--- a/src/components/PluginDialog/index.vue
+++ b/src/components/PluginDialog/index.vue
@@ -22,6 +22,9 @@
     <el-dialog
       :title="'Plugin ' + name + ' Edit'"
       :visible.sync="showDialog"
+      :before-close="onCancel"
+      :close-on-press-escape="false"
+      :close-on-click-modal="false"
     >
       <el-form
         v-if="schema.oneOf"


### PR DESCRIPTION
The PR has fixed a bug that if close the plugin dialog not by the cancel button, we can never open a new one.